### PR TITLE
README.md: add -a option to usermod to avoid loosing existing groups …

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ For a better solution, we will need to follow a few more steps.
 
 First, add your user to the "plugdev" group:
 ```
-sudo usermod -G plugdev $(whoami)
+sudo usermod -a -G plugdev $(whoami)
 ```
 We will use ths group to control access to USB devices.  After running this, sign out and back in again to make the change effective.
 


### PR DESCRIPTION
…when adding plugdev

The README.md manual states to add the user to the plugdev group with the usermod -G command. Doing so, the user will lose existing groups, including sudo which is mandatory on ubuntu. This pull request adds the -a option to *add* the new group without removing the existing.